### PR TITLE
Add missing type signature for Element#get

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -147,6 +147,7 @@ export class Element extends Node {
     find(xpath: string, ns_uri?: string): Node[];
     find(xpath: string, namespaces: StringMap): Node[];
     get(xpath: string, ns_uri?: string): Element|null;
+    get(xpath: string, namespaces: StringMap): Element|null;
 
     defineNamespace(prefixOrHref: string, hrefInCaseOfPrefix?: string): Namespace;
 


### PR DESCRIPTION
Since `Element#get` is essentially a convenience wrapper around
`Element#find` [1], both of them support the same arguments. This fact
was not reflected in the TypeScript definitions, which were missing
the get(string, StringMap) variant.

https://github.com/marudor/libxmljs2/blob/96287b64c6e386d60ba1fc6336522f32a9ea1100/lib/element.js#L63