### PR TITLE
index.d.ts: Add type definition for Element.attr() setter.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -126,8 +126,9 @@ export class Element extends Node {
     name(newName: string): this;
     text(): string;
     text(newText: string): this;
-    attr(name: string): Attribute|null;
-    attr(attrObject: StringMap): this;
+    attr(name: string): Attribute|null; //getter
+    attr(name: string, value: string): this; //setter
+    attr(attrObject: StringMap): this; //setter using stringMap
     attrs(): Attribute[];
 
     doc(): Document;


### PR DESCRIPTION
Added another case of `Element.attr()` setter to type definition:

See https://github.com/marudor/libxmljs2/blob/master/lib/element.js#L38-L42.
When there are 2 args, it is a setter.