### PR TITLE
use NODE_MODULE_INIT with proper context for Node.js worker

### DIFF
--- a/src/libxmljs.cc
+++ b/src/libxmljs.cc
@@ -265,6 +265,8 @@ NAN_MODULE_INIT(init)
       Nan::SetMethod(target, "xmlNodeCount", XmlNodeCount);
 }
 
-NODE_MODULE(xmljs, init)
+NODE_MODULE_INIT(/* exports, module, context */) {
+  Init(exports, context);
+}
 
 }  // namespace libxmljs


### PR DESCRIPTION
Init Node.js module with context to support Node.js thread.