### PR TITLE
TypeScript: fix Element.prototype.addChild type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -156,7 +156,7 @@ export class Element extends Node {
   /**
    * @return The original element, not the child.
    */
-  addChild(child: Element): this;
+  addChild(child: Node): this;
 
   prevElement(): Element | null;
   nextElement(): Element | null;


### PR DESCRIPTION
The function isn't limited to just elements, the child an be any XML
node.