### PR TITLE
TypeScript: Do not export Attribute

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -180,7 +180,7 @@ export class Element extends Node {
   path(): string;
 }
 
-export class Attribute extends Node {
+declare class Attribute extends Node {
   name(): string;
   node(): Element;
   value(): string;


### PR DESCRIPTION
The Attribute class isn't exported in the JS side, so we shouldn't export it on the TS side either.