### PR TITLE
Added encoding for toString() method

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -133,6 +133,7 @@ export class Node {
           selfCloseEmpty: boolean;
           whitespace: boolean;
           type: 'xml' | 'html' | 'xhtml';
+          encoding?: 'HTML' | 'ASCII' | 'UTF-8' | 'UTF-16' | 'ISO-Latin-1' | 'ISO-8859-1';
         }
   ): string;
 }

--- a/src/xml_document.cc
+++ b/src/xml_document.cc
@@ -184,9 +184,17 @@ NAN_METHOD(XmlDocument::ToString) {
   assert(document);
 
   int options = 0;
+  const char *encoding = "UTF-8";
 
   if (info[0]->IsObject()) {
     Local<Object> obj = Nan::To<Object>(info[0]).ToLocalChecked();
+
+    // choose encoding declaration
+    v8::Local<v8::Value> encodingOpt = Nan::Get(obj, Nan::New<v8::String>("encoding").ToLocalChecked()).ToLocalChecked();
+    if (encodingOpt->IsString()) {
+      std::string encoding_ = *Nan::Utf8String(encodingOpt);
+      encoding = encoding_.c_str();
+    }
 
     // drop the xml declaration
     if (Nan::Get(obj, Nan::New<String>("declaration").ToLocalChecked())
@@ -245,7 +253,7 @@ NAN_METHOD(XmlDocument::ToString) {
   }
 
   xmlBuffer *buf = xmlBufferCreate();
-  xmlSaveCtxt *savectx = xmlSaveToBuffer(buf, "UTF-8", options);
+  xmlSaveCtxt *savectx = xmlSaveToBuffer(buf, encoding, options);
   xmlSaveTree(savectx, (xmlNode *)document->xml_obj);
   xmlSaveFlush(savectx);
   xmlSaveClose(savectx);

--- a/test/html_parser.test.js
+++ b/test/html_parser.test.js
@@ -164,4 +164,31 @@ describe('html parser', () => {
       doc.toString({ type: 'xml', selfCloseEmpty: true }).indexOf('<a/>') > -1
     ).toBeTruthy();
   });
+
+  it('toString with encoding', () => {
+    let doc = libxml.parseHtml('<a>Something&nbsp;with a space</a>');
+    expect(doc.toString({ type: 'xhtml' })).toEqual(
+      expect.not.stringContaining('&nbsp;')
+    );
+    expect(doc.toString({ type: 'xhtml', encoding: 'UTF-8' })).toEqual(
+      doc.toString({ type: 'xhtml' })
+    );
+    expect(doc.toString({ type: 'xhtml', encoding: 'HTML' })).toEqual(
+      expect.stringContaining('&nbsp;')
+    );
+    expect(doc.toString({ type: 'xhtml', encoding: 'ASCII' })).toEqual(
+      expect.stringContaining('&#160;')
+    );
+
+    doc = libxml.parseHtml('<a>Something with an emoji 😀</a>');
+    expect(doc.toString({ type: 'xhtml', encoding: 'UTF-8' })).toEqual(
+      expect.stringContaining('😀')
+    );
+    expect(doc.toString({ type: 'xhtml', encoding: 'HTML' })).toEqual(
+      expect.stringContaining('&#128512')
+    );
+    expect(doc.toString({ type: 'xhtml', encoding: 'ASCII' })).toEqual(
+      expect.stringContaining('&#128512')
+    );
+  });
 });


### PR DESCRIPTION
[Added](https://github.com/libxmljs/libxmljs/pull/482) this a _while ago_ and now porting over - also added in the updated types.

Thanks for taking on and updating the lib!
 