### PR TITLE
added BUILDING_NODE_EXTENSION define to binding.gyp

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -8,7 +8,7 @@
             "cflags": ["-Wall"],
             "xcode_settings": {"OTHER_CFLAGS": ["-Wall"]},
             "win_delay_load_hook": "false",
-            "defines": ["LIBXML_XINCLUDE_ENABLED"],
+            "defines": ["LIBXML_XINCLUDE_ENABLED", "BUILDING_NODE_EXTENSION"],
             "sources": [
                 "src/libxmljs.cc",
                 "src/xml_attribute.cc",

--- a/binding.gyp
+++ b/binding.gyp
@@ -7,7 +7,7 @@
             "include_dirs": ["vendor/libxml/include", "<!(node -e \"require('nan')\")"],
             "cflags": ["-Wall"],
             "xcode_settings": {"OTHER_CFLAGS": ["-Wall"]},
-            "win_delay_load_hook": "false",
+            "win_delay_load_hook": "true",
             "defines": ["LIBXML_XINCLUDE_ENABLED", "BUILDING_NODE_EXTENSION"],
             "sources": [
                 "src/libxmljs.cc",


### PR DESCRIPTION
0.26.4 broke electron compatibility under windows, since delay_load_hook was removed
this PR restores electron support

- added back delay_load_hook to allow for electron builds on windows
- then added BUILDING_NODE_EXTENSION define to binding.gyp (this prevents linking issue with /DELAYLOAD)
