### PR TITLE
Add `Buffer` to available source types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -44,19 +44,25 @@ interface ParserOptions {
   baseUrl?: string;
 }
 
-export function parseXml(source: string, options?: ParserOptions): Document;
+export function parseXml(
+  source: string | Buffer,
+  options?: ParserOptions
+): Document;
 export function parseXmlString(
   source: string,
   options?: ParserOptions
 ): Document;
 
-export function parseHtml(source: string, options?: ParserOptions): Document;
+export function parseHtml(
+  source: string | Buffer,
+  options?: ParserOptions
+): Document;
 export function parseHtmlString(
   source: string,
   options?: ParserOptions
 ): Document;
 export function parseHtmlFragment(
-  source: string,
+  source: string | Buffer,
   options?: ParserOptions
 ): Document;
 


### PR DESCRIPTION
All parse functions can take a `Buffer` as an input ([FromXml](https://github.com/marudor/libxmljs2/blob/793352def67324ef1ec2724bb55eb1e9c6f2fc3f/src/xml_document.cc#L537-L546), [FromHtml](https://github.com/marudor/libxmljs2/blob/793352def67324ef1ec2724bb55eb1e9c6f2fc3f/src/xml_document.cc#L473-L482)).

In theory this also applies to the `parseXmlString` and `parseHtmlString` functions since they call the same function under the hood, but adding the `Buffer` type there might cause confusion to users.